### PR TITLE
Include extra headers to resolve compiler errors on Visual Studio 2010

### DIFF
--- a/Demos/ClothDemo/TriangleModel.h
+++ b/Demos/ClothDemo/TriangleModel.h
@@ -5,6 +5,7 @@
 #include "Demos/Utils/IndexedFaceMesh.h"
 #include "Demos/Utils/ParticleData.h"
 #include <vector>
+#include <Eigen/StdVector>
 
 namespace PBD 
 {	

--- a/Demos/RigidBodyDemo/RigidBodyModel.h
+++ b/Demos/RigidBodyDemo/RigidBodyModel.h
@@ -4,6 +4,7 @@
 #include "Demos/Utils/Config.h"
 #include <vector>
 #include "Demos/Utils/RigidBody.h"
+#include <Eigen/StdVector>
 
 namespace PBD 
 {	

--- a/Demos/Utils/IndexedFaceMesh.h
+++ b/Demos/Utils/IndexedFaceMesh.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <Eigen/Dense>
+#include <iterator>
 
 namespace PBD 
 {


### PR DESCRIPTION
Include iterator and StdVector (http://eigen.tuxfamily.org/dox/group_TopicStlContainers.html) headers to resolve compiler errors in Visual Studio 2010