### PR TITLE
Port MiniGL to OpenGL 3.3 Core (macOS compatibility)

### DIFF
--- a/Common/Common.h
+++ b/Common/Common.h
@@ -36,10 +36,14 @@ using Matrix2r = Eigen::Matrix<Real, 2, 2, Eigen::DontAlign>;
 using Matrix3r = Eigen::Matrix<Real, 3, 3, Eigen::DontAlign>;
 using Matrix4r = Eigen::Matrix<Real, 4, 4, Eigen::DontAlign>;
 using Vector2i = Eigen::Matrix<int, 2, 1, Eigen::DontAlign>;
+using Vector3f = Eigen::Matrix<float, 3, 1, Eigen::DontAlign>;
+using Matrix4f = Eigen::Matrix<float, 4, 4, Eigen::DontAlign>;
 using AlignedBox2r = Eigen::AlignedBox<Real, 2>;
 using AlignedBox3r = Eigen::AlignedBox<Real, 3>;
 using AngleAxisr = Eigen::AngleAxis<Real>;
 using Quaternionr = Eigen::Quaternion<Real, Eigen::DontAlign>;
+using VectorXr = Eigen::Matrix<Real, -1, 1, 0, -1, 1>;
+using VectorXf = Eigen::Matrix<float, -1, 1, 0, -1, 1>;
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64)
 	// Enable memory leak detection

--- a/Demos/Common/DemoBase.cpp
+++ b/Demos/Common/DemoBase.cpp
@@ -217,8 +217,7 @@ void DemoBase::init(int argc, char **argv, const char *demoName)
 	MiniGL::setViewport(40.0, 0.1f, 500.0, Vector3r(0.0, 3.0, 8.0), Vector3r(0.0, 0.0, 0.0));
 	MiniGL::setSelectionFunc(selection, this);
 
-	if (MiniGL::checkOpenGLVersion(3, 3))
-		initShaders();
+	initShaders();
 
 	m_gui->initImgui();
 }
@@ -237,6 +236,8 @@ void DemoBase::readScene()
 
 void DemoBase::initShaders()
 {
+	MiniGL::initShaders(m_exePath + "/resources/shaders");
+
 	std::string vertFile = m_exePath + "/resources/shaders/vs_smooth.glsl";
 	std::string fragFile = m_exePath + "/resources/shaders/fs_smooth.glsl";
 	m_shader.compileShaderFile(GL_VERTEX_SHADER, vertFile);
@@ -279,6 +280,13 @@ void DemoBase::initShaders()
 	m_shaderFlat.end();
 }
 
+void DemoBase::destroyShaders()
+{
+	m_shader.destroy();
+	m_shaderTex.destroy();
+	m_shaderFlat.destroy();
+	MiniGL::destroyShaders();
+}
 
 void DemoBase::shaderTexBegin(const float *col)
 {
@@ -286,12 +294,10 @@ void DemoBase::shaderTexBegin(const float *col)
 	glUniform1f(m_shaderTex.getUniform("shininess"), 5.0f);
 	glUniform1f(m_shaderTex.getUniform("specular_factor"), 0.2f);
 
-	GLfloat matrix[16];
-	glGetFloatv(GL_MODELVIEW_MATRIX, matrix);
-	glUniformMatrix4fv(m_shaderTex.getUniform("modelview_matrix"), 1, GL_FALSE, matrix);
-	GLfloat pmatrix[16];
-	glGetFloatv(GL_PROJECTION_MATRIX, pmatrix);
-	glUniformMatrix4fv(m_shaderTex.getUniform("projection_matrix"), 1, GL_FALSE, pmatrix);
+	const Matrix4f matrix(MiniGL::getModelviewMatrix().cast<float>());
+	glUniformMatrix4fv(m_shaderTex.getUniform("modelview_matrix"), 1, GL_FALSE, &matrix(0,0));
+	const Matrix4f pmatrix(MiniGL::getProjectionMatrix().cast<float>());
+	glUniformMatrix4fv(m_shaderTex.getUniform("projection_matrix"), 1, GL_FALSE, &pmatrix(0,0));
 	glUniform3fv(m_shaderTex.getUniform("surface_color"), 1, col);
 }
 
@@ -306,12 +312,10 @@ void DemoBase::shaderBegin(const float *col)
 	glUniform1f(m_shader.getUniform("shininess"), 5.0f);
 	glUniform1f(m_shader.getUniform("specular_factor"), 0.2f);
 
-	GLfloat matrix[16];
-	glGetFloatv(GL_MODELVIEW_MATRIX, matrix);
-	glUniformMatrix4fv(m_shader.getUniform("modelview_matrix"), 1, GL_FALSE, matrix);
-	GLfloat pmatrix[16];
-	glGetFloatv(GL_PROJECTION_MATRIX, pmatrix);
-	glUniformMatrix4fv(m_shader.getUniform("projection_matrix"), 1, GL_FALSE, pmatrix);
+	const Matrix4f matrix(MiniGL::getModelviewMatrix().cast<float>());
+	glUniformMatrix4fv(m_shader.getUniform("modelview_matrix"), 1, GL_FALSE, &matrix(0,0));
+	const Matrix4f pmatrix(MiniGL::getProjectionMatrix().cast<float>());
+	glUniformMatrix4fv(m_shader.getUniform("projection_matrix"), 1, GL_FALSE, &pmatrix(0,0));
 	glUniform3fv(m_shader.getUniform("surface_color"), 1, col);
 }
 
@@ -326,12 +330,10 @@ void DemoBase::shaderFlatBegin(const float* col)
 	glUniform1f(m_shaderFlat.getUniform("shininess"), 5.0f);
 	glUniform1f(m_shaderFlat.getUniform("specular_factor"), 0.2f);
 
-	GLfloat matrix[16];
-	glGetFloatv(GL_MODELVIEW_MATRIX, matrix);
-	glUniformMatrix4fv(m_shaderFlat.getUniform("modelview_matrix"), 1, GL_FALSE, matrix);
-	GLfloat pmatrix[16];
-	glGetFloatv(GL_PROJECTION_MATRIX, pmatrix);
-	glUniformMatrix4fv(m_shaderFlat.getUniform("projection_matrix"), 1, GL_FALSE, pmatrix);
+	const Matrix4f matrix(MiniGL::getModelviewMatrix().cast<float>());
+	glUniformMatrix4fv(m_shaderFlat.getUniform("modelview_matrix"), 1, GL_FALSE, &matrix(0,0));
+	const Matrix4f pmatrix(MiniGL::getProjectionMatrix().cast<float>());
+	glUniformMatrix4fv(m_shaderFlat.getUniform("projection_matrix"), 1, GL_FALSE, &pmatrix(0,0));
 	glUniform3fv(m_shaderFlat.getUniform("surface_color"), 1, col);
 }
 
@@ -652,15 +654,14 @@ void DemoBase::renderTetModels()
 
 void DemoBase::renderAABB(AABB &aabb)
 {
+	float color[4] = { 0.5f, 0.5f, 0.5f, 0.3f };
+
 	Vector3r p1, p2;
-	glBegin(GL_LINES);
 	for (unsigned char i = 0; i < 12; i++)
 	{
 		AABB::getEdge(aabb, i, p1, p2);
-		glVertex3d(p1[0], p1[1], p1[2]);
-		glVertex3d(p2[0], p2[1], p2[2]);
+		MiniGL::drawVector(p1, p2, 1.0f, color);
 	}
-	glEnd();
 }
 
 void DemoBase::renderSDF(CollisionDetection::CollisionObject* co)

--- a/Demos/Common/DemoBase.h
+++ b/Demos/Common/DemoBase.h
@@ -122,6 +122,7 @@ namespace PBD
 		Shader& getShader() { return m_shader; }
 		Shader& getShaderTex() { return m_shaderTex; }
 		Shader& getShaderFlat() { return m_shaderFlat; }
+		void destroyShaders();
 		void shaderTexBegin(const float *col);
 		void shaderTexEnd();
 		void shaderBegin(const float *col);

--- a/Demos/Common/Simulator_GUI_imgui.cpp
+++ b/Demos/Common/Simulator_GUI_imgui.cpp
@@ -410,6 +410,7 @@ void Simulator_GUI_imgui::destroy()
 	ImGui_ImplOpenGL3_Shutdown();
 	ImGui_ImplGlfw_Shutdown();
 	ImGui::DestroyContext();
+	m_base->destroyShaders();
 }
 
 void Simulator_GUI_imgui::switchPause()

--- a/Demos/Visualization/Selection.h
+++ b/Demos/Visualization/Selection.h
@@ -10,10 +10,8 @@
 
 #ifdef __APPLE__
 #include <OpenGL/GL.h>
-#include <OpenGL/GLU.h>
 #else
 #include "GL/gl.h"
-#include "GL/glu.h"
 #endif
 
 #include <vector>
@@ -43,34 +41,25 @@ namespace PBD
 			int itop = ip1y > ip2y ? ip1y : ip2y;
 			int ibottom = ip1y < ip2y ? ip1y : ip2y;
 
-			float left = (float)ileft;
-			float right = (float)iright;
-			float top = (float)itop;
-			float bottom = (float)ibottom;
+			float left = (float)ileft * MiniGL::getDevicePixelRatio();
+			float right = (float)iright * MiniGL::getDevicePixelRatio();
+			float top = (float)itop * MiniGL::getDevicePixelRatio();
+			float bottom = (float)ibottom * MiniGL::getDevicePixelRatio();
 
 			if (left != right && top != bottom)
 			{
 				GLint viewport[4];
-				GLdouble mv[16],pm[16];
 				glGetIntegerv(GL_VIEWPORT, viewport);
-				glGetDoublev(GL_MODELVIEW_MATRIX, mv);
-				glGetDoublev(GL_PROJECTION_MATRIX, pm);
 
-				GLdouble resx,resy,resz;
 				float zNear = MiniGL::getZNear();
 				float zFar = MiniGL::getZFar();
-				gluUnProject(left, viewport[3] - top, zNear , mv, pm, viewport, &resx, &resy, &resz);
-				const Vector3r vector0((Real)resx, (Real)resy, (Real)resz);
-				gluUnProject(left, viewport[3] - top, zFar , mv, pm, viewport, &resx, &resy, &resz);
-				const Vector3r vector1((Real)resx, (Real)resy, (Real)resz);
-				gluUnProject(left, viewport[3] - bottom, zNear , mv, pm, viewport, &resx, &resy, &resz);
-				const Vector3r vector2((Real)resx, (Real)resy, (Real)resz);
-				gluUnProject(right, viewport[3] - top, zNear , mv, pm, viewport, &resx, &resy, &resz);
-				const Vector3r vector3((Real)resx, (Real)resy, (Real)resz);
-				gluUnProject(right, viewport[3] - bottom, zNear , mv, pm, viewport, &resx, &resy, &resz);
-				const Vector3r vector4((Real)resx, (Real)resy, (Real)resz);
-				gluUnProject(right, viewport[3] - bottom, zFar , mv, pm, viewport, &resx, &resy, &resz);
-				const Vector3r vector5((Real)resx, (Real)resy, (Real)resz);
+				Vector3r vector0, vector1, vector2, vector3, vector4, vector5;
+				MiniGL::unproject(Vector3r(left, viewport[3] - top, zNear), vector0);
+				MiniGL::unproject(Vector3r(left, viewport[3] - top, zFar), vector1);
+				MiniGL::unproject(Vector3r(left, viewport[3] - bottom, zNear), vector2);
+				MiniGL::unproject(Vector3r(right, viewport[3] - top, zNear), vector3);
+				MiniGL::unproject(Vector3r(right, viewport[3] - bottom, zNear), vector4);
+				MiniGL::unproject(Vector3r(right, viewport[3] - bottom, zFar), vector5);
 
 				SelectionPlane plane[4];
 				plane[0].normal = (vector3-vector0).cross(vector1-vector0);

--- a/Demos/Visualization/Shader.cpp
+++ b/Demos/Visualization/Shader.cpp
@@ -17,11 +17,7 @@ Shader::Shader(void)
 
 Shader::~Shader(void)
 {
-	m_initialized = false;
-	m_attributes.clear();
-	m_uniforms.clear();
-	if (m_program)
-		glDeleteProgram(m_program);
+	destroy();
 }
 
 void Shader::compileShaderString(GLenum type, const std::string &source) 
@@ -83,6 +79,18 @@ void Shader::createAndLinkProgram()
 
 	for (unsigned char i = 0; i < 3; i++)
 		glDeleteShader(m_shaders[i]);
+}
+
+void Shader::destroy()
+{
+	m_initialized = false;
+	m_attributes.clear();
+	m_uniforms.clear();
+	if (m_program)
+	{
+		glDeleteProgram(m_program);
+		m_program = 0;
+	}
 }
 
 void Shader::begin() 

--- a/Demos/Visualization/Shader.h
+++ b/Demos/Visualization/Shader.h
@@ -16,6 +16,7 @@ namespace PBD
 		void compileShaderString(GLenum whichShader, const std::string &source);
 		void compileShaderFile(GLenum whichShader, const std::string &filename);
 		void createAndLinkProgram();
+		void destroy();
 		void addAttribute(const std::string &attribute);
 		void addUniform(const std::string &uniform);
 		bool isInitialized();

--- a/Demos/Visualization/Visualization.h
+++ b/Demos/Visualization/Visualization.h
@@ -3,6 +3,7 @@
 
 #include "Common/Common.h"
 #include "MiniGL.h"
+#include "Utils/IndexedFaceMesh.h"
 
 namespace PBD
 {
@@ -23,40 +24,14 @@ namespace PBD
 		const unsigned int nFaces = mesh.numFaces();
 		const Vector3r *vertexNormals = mesh.getVertexNormals().data();
 
-		if (MiniGL::checkOpenGLVersion(3, 3))
-		{
-			glEnableVertexAttribArray(0);
-			glVertexAttribPointer(0, 3, GL_REAL, GL_FALSE, 0, &pd.getPosition(offset)[0]);
-			glEnableVertexAttribArray(2);
-			glVertexAttribPointer(2, 3, GL_REAL, GL_FALSE, 0, &vertexNormals[0][0]);
-		}
-		else
-		{
-			float speccolor[4] = { 1.0, 1.0, 1.0, 1.0 };
-			glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, color);
-			glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, color);
-			glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, speccolor);
-			glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, 100.0f);
-			glColor3fv(color);
+		MiniGL::supplyVertices(0, mesh.numVertices(), &pd.getPosition(offset)[0]);
+		MiniGL::supplyNormals(2, mesh.numVertices(), &vertexNormals[0][0]);
+		MiniGL::supplyFaces(3 * nFaces, faces);
 
-			glEnableClientState(GL_VERTEX_ARRAY);
-			glEnableClientState(GL_NORMAL_ARRAY);
-			glVertexPointer(3, GL_REAL, 0, &pd.getPosition(0)[0]);
-			glNormalPointer(GL_REAL, 0, &vertexNormals[0][0]);
-		}
+		glDrawElements(GL_TRIANGLES, (GLsizei)3 * nFaces, GL_UNSIGNED_INT, (void*)0);
 
-		glDrawElements(GL_TRIANGLES, (GLsizei)3 * mesh.numFaces(), GL_UNSIGNED_INT, mesh.getFaces().data());
-
-		if (MiniGL::checkOpenGLVersion(3, 3))
-		{
-			glDisableVertexAttribArray(0);
-			glDisableVertexAttribArray(2);
-		}
-		else
-		{
-			glDisableClientState(GL_VERTEX_ARRAY);
-			glDisableClientState(GL_NORMAL_ARRAY);
-		}
+		glDisableVertexAttribArray(0);
+		glDisableVertexAttribArray(2);
 	}
 
 	template<class PositionData>
@@ -70,46 +45,16 @@ namespace PBD
 
 		MiniGL::bindTexture();
 
-		if (MiniGL::checkOpenGLVersion(3,3))
-		{
-			glEnableVertexAttribArray(0);
-			glVertexAttribPointer(0, 3, GL_REAL, GL_FALSE, 0, &pd.getPosition(offset)[0]);
-			glEnableVertexAttribArray(1);
-			glVertexAttribPointer(1, 2, GL_REAL, GL_FALSE, 0, &uvs[0][0]);
-			glEnableVertexAttribArray(2);
-			glVertexAttribPointer(2, 3, GL_REAL, GL_FALSE, 0, &vertexNormals[0][0]);
-		}
-		else
-		{
-			float speccolor[4] = { 1.0, 1.0, 1.0, 1.0 };
-			glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, color);
-			glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, color);
-			glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, speccolor);
-			glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, 100.0);
-			glColor3fv(color);
+		MiniGL::supplyVertices(0, mesh.numVertices(), &pd.getPosition(offset)[0]);
+		MiniGL::supplyTexcoords(1, mesh.numUVs(), &uvs[0][0]);
+		MiniGL::supplyNormals(2, mesh.numVertices(), &vertexNormals[0][0]);
+		MiniGL::supplyFaces(3 * nFaces, faces);
 
-			glEnableClientState(GL_VERTEX_ARRAY);
-			glEnableClientState(GL_NORMAL_ARRAY);
-			glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-			glVertexPointer(3, GL_REAL, 0, &pd.getPosition(0)[0]);
-			glTexCoordPointer(2, GL_REAL, 0, &uvs[0][0]);
-			glNormalPointer(GL_REAL, 0, &vertexNormals[0][0]);
-		}
+		glDrawElements(GL_TRIANGLES, (GLsizei)3 * nFaces, GL_UNSIGNED_INT, (void*)0);
 
-		glDrawElements(GL_TRIANGLES, (GLsizei)3 * mesh.numFaces(), GL_UNSIGNED_INT, mesh.getFaces().data());	
-
-		if (MiniGL::checkOpenGLVersion(3, 3))
-		{
-			glDisableVertexAttribArray(0);
-			glDisableVertexAttribArray(1);
-			glDisableVertexAttribArray(2);
-		}
-		else
-		{
-			glDisableClientState(GL_VERTEX_ARRAY);
-			glDisableClientState(GL_NORMAL_ARRAY);
-			glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-		}
+		glDisableVertexAttribArray(0);
+		glDisableVertexAttribArray(1);
+		glDisableVertexAttribArray(2);
 
 		MiniGL::unbindTexture();
 	}

--- a/data/shaders/fs_flatTex.glsl
+++ b/data/shaders/fs_flatTex.glsl
@@ -36,7 +36,7 @@ void main()
     float cos_nh = max(dot(eye_n, h), 0.0);   
     
 	vec3 color = surface_color * (ambient + diffuse * cos_ln + specular_factor * specular * pow(cos_nh, shininess));
-	vec4 color2 = texture2D(tex, inData.texCoord) * vec4(color, 1.0);
+	vec4 color2 = texture(tex, inData.texCoord) * vec4(color, 1.0);
 
 	frag_color = color2;
 }

--- a/data/shaders/fs_smoothTex.glsl
+++ b/data/shaders/fs_smoothTex.glsl
@@ -36,7 +36,7 @@ void main()
     float cos_nh = max(dot(eye_n, h), 0.0);   
     
 	vec3 color = surface_color * (ambient + diffuse * cos_ln + specular_factor * specular * pow(cos_nh, shininess));
-	vec4 color2 = texture2D(tex, inData.texCoord) * vec4(color, 1.0);
+	vec4 color2 = texture(tex, inData.texCoord) * vec4(color, 1.0);
 
     frag_color = color2;
 }

--- a/data/shaders/mini.frag
+++ b/data/shaders/mini.frag
@@ -1,0 +1,52 @@
+#version 330
+
+#define NUM_LIGHTS 3
+
+uniform bool lighting;
+uniform vec3 ambientIntensity;
+uniform vec3 diffuseIntensity[NUM_LIGHTS];
+uniform vec3 specularIntensity[NUM_LIGHTS];
+uniform vec3 lightPosition[NUM_LIGHTS];
+uniform vec3 ambientReflectance;
+uniform vec3 diffuseReflectance;
+uniform vec3 specularReflectance;
+uniform float shininess;
+
+in VertexData {
+	vec3 position;
+	vec3 normal;
+} IN;
+
+out vec4 outColor;
+
+void main()
+{
+	if (lighting)
+	{
+		vec3 view = normalize(-IN.position);
+		vec3 normal = normalize(IN.normal);
+
+		// Compute the ambient lighting.
+		vec3 color = ambientReflectance * ambientIntensity;
+
+		for (int i = 0; i < NUM_LIGHTS; i++)
+		{
+			vec3 light = normalize(lightPosition[i] - IN.position);
+			float diffuseFactor = max(dot(normal, light), 0.0);
+			if (diffuseFactor > 0.0)
+			{
+				// Compute the diffuse lighting using the Lambertian model.
+				color += diffuseFactor * diffuseReflectance * diffuseIntensity[i];
+
+				vec3 halfway = normalize(light + view);
+				float specularFactor = pow(max(dot(halfway, normal), 0.0), shininess);
+
+				// Compute the specular lighting using the Blinn-Phong model.
+				color += specularFactor * specularReflectance * specularIntensity[i];
+			}
+		}
+
+		outColor = vec4(color, 1.0);
+	}
+	else outColor = vec4(diffuseReflectance, 1.0);
+}

--- a/data/shaders/mini.vert
+++ b/data/shaders/mini.vert
@@ -1,0 +1,22 @@
+#version 330
+
+uniform mat4 modelview_matrix;
+uniform mat4 projection_matrix;
+uniform float pointSize;
+
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec3 normal;
+
+out VertexData {
+	vec3 position;
+	vec3 normal;
+} OUT;
+
+void main()
+{
+	vec4 vertexPosition = modelview_matrix * vec4(position, 1.0);
+	OUT.position = vertexPosition.xyz / vertexPosition.w;
+	OUT.normal = mat3(modelview_matrix) * normal;
+	gl_Position = projection_matrix * vertexPosition;
+	gl_PointSize = pointSize;
+}

--- a/data/shaders/mini_screen.frag
+++ b/data/shaders/mini_screen.frag
@@ -1,0 +1,10 @@
+#version 330
+
+uniform vec3 color;
+
+out vec4 outColor;
+
+void main()
+{
+	outColor = vec4(color, 1.0);
+}

--- a/data/shaders/mini_screen.vert
+++ b/data/shaders/mini_screen.vert
@@ -1,0 +1,12 @@
+#version 330
+
+uniform float width;
+uniform float height;
+
+layout(location = 0) in vec2 position;
+
+void main()
+{
+	// Project the screen position to NDC (cf. glOrtho).
+	gl_Position = vec4(2.0 * (position.x / width) - 1.0, -2.0 * (position.y / height) + 1.0, -1.0, 1.0);
+}


### PR DESCRIPTION
This PR carries the MiniGL port over from [SPlisHSPlasH#167](https://github.com/InteractiveComputerGraphics/SPlisHSPlasH/pull/167) to enable the same visual experience on macOS.